### PR TITLE
Create draft codemeta.json file

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -1,0 +1,48 @@
+{
+    "@context": "https://w3id.org/codemeta/3.0",
+    "applicationCategory": "SoftwareSourceCode",
+    "author": [
+        {
+            "name": "British Library",
+            "@id": "https://github.com/britishlibrary",
+            "@type": "Organization"
+        }
+    ],
+    "codeRepository": "https://github.com/britishlibrary/peripleo",
+    "contributor": [
+        {
+            "familyName": "Gadd",
+            "givenName": "Stephen",
+            "@id": "https://github.com/docuracy",
+            "@type": "Person"
+        },
+        {
+            "familyName": "Simon",
+            "givenName": "Rainer",
+            "@id": "https://github.com/rsimon",
+            "@type": "Person"
+        },
+        {
+            "familyName": "Rees",
+            "givenName": "Gethin",
+            "@id": "https://github.com/thegsi",
+            "@type": "Person"
+        }
+    ],
+    "dateCreated": "2022-04-23",
+    "dateModified": "2026-01-02",
+    "description": "Example configuration of Peripleo geodata mapping software, developed for the BL's \"Locating a National Collection\" project - fork this!",
+    "downloadUrl": "https://github.com/britishlibrary/peripleo/releases",
+    "identifier": "peripleo",
+    "keywords": [
+        "visualisation",
+        "collection",
+        "british library",
+        "mapping",
+        "ahrc"
+    ],
+    "license": "https://spdx.org/licenses/MIT",
+    "name": "Peripleo",
+    "issueTracker": "https://github.com/britishlibrary/peripleo/issues",
+    "@type": "SoftwareSourceCode"
+}


### PR DESCRIPTION
Further to the email sent to Gethin Rees last week on behalf of the [CCP-AHC](https://www.ccpahc.ac.uk/) project, I'm opening this pull request to contribute a `codemeta.json` file.
Codemeta is a schema designed to enable software citation by standardising metadata about the project. It is defined and documented at https://codemeta.github.io/.
This pull request creates a file to that standard for this repository, starting from the details automatically filled out by https://autocodemeta.linkeddata.es/ and editing to fill in the gaps the generator is unable to automatically scrape with details manually extracted from the repository and linked pages.

Please do tell me in the discussion where details are inaccurate so that we can bring the codemeta.json file up to date with the project.